### PR TITLE
Remove sys.path hacks

### DIFF
--- a/scripts/ansible_inventory_cli.py
+++ b/scripts/ansible_inventory_cli.py
@@ -44,6 +44,9 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+if __name__ == "__main__" and __package__ is None:
+    __package__ = "scripts"
+
 from .commands.base import BaseCommand  # noqa: E402
 from .core import (  # noqa: E402
     CSV_FILE,
@@ -74,10 +77,10 @@ class CommandRegistry:
         Commands should follow the naming convention: {name}Command
         """
         try:
-            from commands.generate_command import GenerateCommand
-            from commands.health_command import HealthCommand
-            from commands.lifecycle_command import LifecycleCommand
-            from commands.validate_command import ValidateCommand
+            from .commands.generate_command import GenerateCommand
+            from .commands.health_command import HealthCommand
+            from .commands.lifecycle_command import LifecycleCommand
+            from .commands.validate_command import ValidateCommand
 
             self.register("generate", GenerateCommand)
             self.register("health", HealthCommand)

--- a/scripts/ansible_inventory_cli.py
+++ b/scripts/ansible_inventory_cli.py
@@ -44,14 +44,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-# Ensure sibling modules are importable when this file is imported outside of
-# the `scripts` directory
-SCRIPT_DIR = Path(__file__).parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
-
-from commands.base import BaseCommand  # noqa: E402
-from core import (  # noqa: E402
+from .commands.base import BaseCommand  # noqa: E402
+from .core import (  # noqa: E402
     CSV_FILE,
     LOG_LEVEL,
     PROJECT_ROOT,

--- a/scripts/ansible_inventory_cli.py
+++ b/scripts/ansible_inventory_cli.py
@@ -45,6 +45,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 if __name__ == "__main__" and __package__ is None:
+    # Add the parent directory to sys.path so "scripts" is treated as a package
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     __package__ = "scripts"
 
 from .commands.base import BaseCommand  # noqa: E402

--- a/scripts/commands/generate_command.py
+++ b/scripts/commands/generate_command.py
@@ -11,17 +11,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from core import get_logger
-from core.config import get_default_inventory_key
-from managers.inventory_manager import InventoryManager
+from ..core import get_logger
+from ..core.config import get_default_inventory_key
+from ..managers.inventory_manager import InventoryManager
 
 from .base import BaseCommand, CommandResult
 
-# Ensure sibling modules are importable when this file is imported outside of
-# the `scripts` directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 
 
 class GenerateCommand(BaseCommand):

--- a/scripts/commands/health_command.py
+++ b/scripts/commands/health_command.py
@@ -11,16 +11,11 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from core import get_logger
-from managers.validation_manager import ValidationManager
+from ..core import get_logger
+from ..managers.validation_manager import ValidationManager
 
 from .base import BaseCommand, CommandResult
 
-# Ensure sibling modules are importable when this file is imported outside of
-# the `scripts` directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 
 
 class HealthCommand(BaseCommand):

--- a/scripts/commands/lifecycle_command.py
+++ b/scripts/commands/lifecycle_command.py
@@ -11,16 +11,11 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from core import get_logger
-from managers.host_manager import HostManager
+from ..core import get_logger
+from ..managers.host_manager import HostManager
 
 from .base import BaseCommand, CommandResult
 
-# Ensure sibling modules are importable when this file is imported outside of
-# the `scripts` directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 
 
 class LifecycleCommand(BaseCommand):

--- a/scripts/commands/validate_command.py
+++ b/scripts/commands/validate_command.py
@@ -11,17 +11,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from core import get_logger
-from core.utils import create_csv_file, get_csv_template
-from managers.validation_manager import ValidationManager
+from ..core import get_logger
+from ..core.utils import create_csv_file, get_csv_template
+from ..managers.validation_manager import ValidationManager
 
 from .base import BaseCommand, CommandResult
 
-# Ensure sibling modules are importable when this file is imported outside of
-# the `scripts` directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 
 
 class ValidateCommand(BaseCommand):

--- a/scripts/core/utils.py
+++ b/scripts/core/utils.py
@@ -23,11 +23,6 @@ import yaml
 
 from .models import ValidationResult
 
-# Add scripts directory to path for imports
-SCRIPT_DIR = Path(__file__).parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
-
 try:
     from .config import (
         CSV_FILE,

--- a/scripts/managers/group_vars_manager.py
+++ b/scripts/managers/group_vars_manager.py
@@ -3,14 +3,9 @@ import sys
 from pathlib import Path
 from typing import Any, List, Optional
 
-from core import get_logger
-from core.config import load_config
-from core.models import Host
-
-# Ensure sibling modules are importable
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
+from ..core import get_logger
+from ..core.config import load_config
+from ..core.models import Host
 
 
 class GroupVarsManager:

--- a/scripts/managers/host_manager.py
+++ b/scripts/managers/host_manager.py
@@ -14,17 +14,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-# Ensure sibling modules are importable when this file is imported outside of
-# the `scripts` directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
-
-from core import CSV_FILE as DEFAULT_CSV_FILE  # noqa: E402
-from core import get_logger  # noqa: E402
-from core.config import PROJECT_ROOT  # noqa: E402
-from core.models import InventoryConfig  # noqa: E402
-from core.utils import (  # noqa: E402
+from ..core import CSV_FILE as DEFAULT_CSV_FILE  # noqa: E402
+from ..core import get_logger  # noqa: E402
+from ..core.config import PROJECT_ROOT  # noqa: E402
+from ..core.models import InventoryConfig  # noqa: E402
+from ..core.utils import (  # noqa: E402
     log_data_modification,
     log_file_access,
     security_audit_log,
@@ -290,7 +284,7 @@ class HostManager:
         # Confirm cleanup unless auto-confirm
         if not auto_confirm:
             try:
-                from core.utils import get_secure_user_input
+                from ..core.utils import get_secure_user_input
 
                 response = get_secure_user_input(
                     f"Clean up {len(expired_hosts)} expired hosts? [y/N]: ",

--- a/scripts/managers/inventory_manager.py
+++ b/scripts/managers/inventory_manager.py
@@ -15,22 +15,16 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-from core import CSV_FILE as DEFAULT_CSV_FILE
-from core import (
+from ..core import CSV_FILE as DEFAULT_CSV_FILE
+from ..core import (
     HOST_VARS_HEADER,
     ensure_directory_exists,
     get_logger,
     load_csv_data,
 )
-from core.config import get_environment_info_from_code, load_config
-from core.models import Host, InventoryConfig, InventoryStats
-from managers.group_vars_manager import GroupVarsManager
-
-# Ensure sibling modules are importable when imported outside of the `scripts`
-# directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
+from ..core.config import get_environment_info_from_code, load_config
+from ..core.models import Host, InventoryConfig, InventoryStats
+from .group_vars_manager import GroupVarsManager
 
 
 class InventoryManager:

--- a/scripts/managers/validation_manager.py
+++ b/scripts/managers/validation_manager.py
@@ -14,16 +14,10 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-# Ensure sibling modules are importable when imported outside of the `scripts`
-# directory
-SCRIPT_DIR = Path(__file__).parent.parent.absolute()
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
-
-from core import get_logger  # noqa: E402
-from core.config import CSV_FILE  # noqa: E402
-from core.models import InventoryConfig, ValidationResult  # noqa: E402
-from managers.inventory_manager import InventoryManager  # noqa: E402
+from ..core import get_logger  # noqa: E402
+from ..core.config import CSV_FILE  # noqa: E402
+from ..core.models import InventoryConfig, ValidationResult  # noqa: E402
+from .inventory_manager import InventoryManager  # noqa: E402
 
 
 class ValidationManager:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -13,11 +13,11 @@ import sys
 import os
 
 # Add scripts directory to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from core.models import Host
-from core.utils import load_csv_data, validate_hostname, validate_date_format
-from managers.inventory_manager import InventoryManager
+from scripts.core.models import Host
+from scripts.core.utils import load_csv_data, validate_hostname, validate_date_format
+from scripts.managers.inventory_manager import InventoryManager
 
 
 class TestHostModelEdgeCases:


### PR DESCRIPTION
## Summary
- clean up imports by removing runtime `sys.path` manipulation
- rely on package-relative imports in CLI modules
- update tests to import via package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb6dda3a08321b3cdc4f3d40432fe