### PR TITLE
Fix yaml encoding in save_yaml_file

### DIFF
--- a/scripts/core/utils.py
+++ b/scripts/core/utils.py
@@ -625,7 +625,7 @@ def save_yaml_file(
         logger.debug(f"Ensuring directory exists: {path_obj.parent}")
 
         # Write YAML file
-        with open(path_obj, "w") as f:
+        with open(path_obj, "w", encoding="utf-8") as f:
             f.write("---\n")
             if header_comment:
                 f.write(f"# {header_comment}\n")


### PR DESCRIPTION
## Summary
- ensure `save_yaml_file` writes using UTF-8

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68703039e09083218db225e6be0ece1e